### PR TITLE
chore: update query

### DIFF
--- a/octopus.py
+++ b/octopus.py
@@ -79,15 +79,16 @@ def get_account_number(token: str) -> str:
 
 
 GET_HH_BODY = """
-query halfHourlyReadings($accountNumber: String!, $fromDatetime: DateTime, $toDatetime: DateTime) {
+query halfHourlyReadings($accountNumber: String!, $fromDatetime: DateTime, $toDatetime: DateTime, $productCode: String!) {
   account(accountNumber: $accountNumber) {
     properties {
       electricitySupplyPoints {
-        halfHourlyReadings(fromDatetime: $fromDatetime, toDatetime: $toDatetime) {
+        halfHourlyReadings(fromDatetime: $fromDatetime, toDatetime: $toDatetime, productCode: $productCode) {
           startAt
           endAt
           version
           value
+          costEstimate
         }
       }
     }
@@ -101,11 +102,13 @@ def get_hh_readings(
     token: str,
     start_at: datetime.datetime,
     end_at: Optional[datetime.datetime] = None,
+    product_code: str
 ) -> List[HHReading]:
 
     variables = {
         "accountNumber": account_number,
         "fromDatetime": start_at.isoformat(),
+        "productCode": product_code,
     }
     if end_at:
         variables["toDatetime"] = end_at.isoformat()


### PR DESCRIPTION
## Summary
This PR updates example of `halfHourlyReadings` query, which was updated on the prod.


- `costEstimate` added as return value
- `productCode` is required as one of the query variables

```
GET_HH_BODY = """
query halfHourlyReadings($accountNumber: String!, $fromDatetime: DateTime, $toDatetime: DateTime, $productCode: String!) {
  account(accountNumber: $accountNumber) {
    properties {
      electricitySupplyPoints {
        halfHourlyReadings(fromDatetime: $fromDatetime, toDatetime: $toDatetime, productCode: $productCode) {
          startAt
          endAt
          version
          value
          costEstimate
        }
      }
    }
  }
}
"""
```

## 🤚 Need help
I updated body in `octopus.py`, but I assume I also need to maintain other place as well such as something like setting `def get_product_code(???) -> str:` 🙇 