### PR TITLE
[Fix #3] Use `typing.Optional` to represent Union type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A few examples using the Octopus Energy API
 
 ## Local setup
 
+**Make sure your Python version is >= 3.8**
+
 Create a virtual environment and install dependencies:
 ```bash
 python -m venv env

--- a/localtime.py
+++ b/localtime.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Optional
 
 import pytz
 
@@ -14,14 +15,14 @@ def today() -> datetime.date:
 
 
 def days_in_the_past(
-    num_days: int, date_: datetime.date | None = None
+    num_days: int, date_: Optional[datetime.date] = None
 ) -> datetime.date:
     if not date_:
         date_ = today()
     return date_ - datetime.timedelta(days=num_days)
 
 
-def midnight(date_: datetime.date | None = None) -> datetime.datetime:
+def midnight(date_: Optional[datetime.date] = None) -> datetime.datetime:
     if date_ is None:
         date_ = today()
     naive_midnight = datetime.datetime.combine(date_, datetime.datetime.min.time())


### PR DESCRIPTION
# Why
- Python version 3.8 does not allow writing union types as `X | Y`. It's only possible on Python 3.10 according to [pep-0604](https://peps.python.org/pep-0604/)
- Fixes #3 

# What
- Use `typing.Optional` to represent Union type
- Also mention which Python to use to run the app in README